### PR TITLE
Fix Logout to Redirect to Login Form and Prevent 419 Error

### DIFF
--- a/stubs/modules/AdminAuth/Http/Controllers/AuthenticatedSessionController.php
+++ b/stubs/modules/AdminAuth/Http/Controllers/AuthenticatedSessionController.php
@@ -48,6 +48,6 @@ class AuthenticatedSessionController extends AppController
 
         $request->session()->regenerateToken();
 
-        return Inertia::location(config('modular.login-url'));
+        return redirect()->route('adminAuth.loginForm');
     }
 }


### PR DESCRIPTION
**Description:**

- Updated logout() to redirect to the GET route adminAuth.loginForm instead of POST login route. This ensures full page reload.
- Ensures a fresh CSRF token is loaded and prevents 419 Page Expired errors on first login after logout.
- Session is invalidated and CSRF token regenerated for security.